### PR TITLE
Make dots turn yellow like in stock

### DIFF
--- a/Assets/Theme/KerbalUI.uss
+++ b/Assets/Theme/KerbalUI.uss
@@ -825,7 +825,7 @@
 }
 
 .bar-toggle:hover > .bar-toggle-dot {
-    background-color: rgb(255, 255, 255);
+    background-color: rgb(222, 213, 123);
 }
 
 .bar-toggle > .bar-toggle-dot.bar-toggle-dot-open {


### PR DESCRIPTION
I would also make them turn white on click, but that's kind of a hassle with the way CSS and Redux's transition stuff is set up.